### PR TITLE
Making the included packages hard-coded

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     name='multicorn_das',
     use_scm_version=True,  # Automatically use the Git version
     setup_requires=['setuptools_scm'],
-    packages=find_packages(include=['com','multicorn_das'],exclude=['licenses', 'downloaded']),  # Exclude non-package folders
+    packages=["com", "com.rawlabs", "com.rawlabs.protocol", "com.rawlabs.protocol.raw", "com.rawlabs.protocol.das", "com.rawlabs.protocol.das.services", "multicorn_das"],
     exclude_package_data={
         '': ['licenses/*', 'downloaded/*'],  # Exclude any files in these folders
     },


### PR DESCRIPTION
The `find_packages` didn't work correctly, so the package definition is now hard-coded, which will also warn us of any missing packages.