### PR TITLE
RD-14975: LIMIT is received and forwarded as an INT64

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -189,8 +189,6 @@ class DASFdw(ForeignDataWrapper):
 
         grpc_sort_keys = multicorn_sortkeys_to_grpc_sortkeys(sortkeys) if sortkeys else None
 
-        grpc_limit = int(limit) if limit else None
-
         # Create an ExecuteRequest message
         request = ExecuteRequest(
             dasId=self.das_id,
@@ -198,7 +196,7 @@ class DASFdw(ForeignDataWrapper):
             quals=grpc_quals,
             columns=grpc_columns,
             sortKeys=grpc_sort_keys,
-            limit=grpc_limit,
+            limit=limit,
             planId=str(planid)
         )
 


### PR DESCRIPTION
In [the related multicorn2 PR](https://github.com/raw-labs/multicorn2/pull/1), `LIMIT` values are sent as `INT64`. This is the corresponding patch in the python code.