### PR TITLE
RD-14972: Support for nested types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ current_path = os.path.dirname(os.path.realpath(__file__))
 
 RAW_VERSION = "v0.39.0"
 
-DAS_VERSION = "v0.1.3"
+DAS_VERSION = "v0.1.4"
 
 PROTO_FILES = [
     f"https://raw.githubusercontent.com/raw-labs/snapi/{RAW_VERSION}/protocol-raw/src/main/protobuf/com/rawlabs/protocol/raw/types.proto",


### PR DESCRIPTION
* Changed the logic for `record` to be advertised as `HSTORE`. An `HSTORE` is more like a `Map[String, String]`, it can be used for records only when all fields are of `string` type. Otherwise, we advertise records as `JSON`.
* `list` had a bug, that its inner type is flagged as nullable when it is (`type + " NULL"`) but that isn't a valid syntax for an array. An array _inner_ type is systematically nullable in postgres, and adding the `NULL` flag isn't accepted.
* Added support for `any` type exposed as `JSON`
* Added support `list` values which weren't implemented.
```sql
# SELECT * FROM schema.nested ;
 listInt |     listList      | listNullables |               nested-record               |                     nested-record2                     | number |       record       | string  
---------+-------------------+---------------+-------------------------------------------+--------------------------------------------------------+--------+--------------------+---------
 {1,2,3} | {{1,2,3},{4,5,6}} | {1,2,NULL}    | {"a": {"a": 12, "b": 14}, "b": [1, 2, 3]} | {"a": {"a": 12, "b": 14}, "b": [[1, 2, 3], [4, 5, 6]]} |     12 | {"a": 12, "b": 14} | tralala
(1 row)
```