### PR TITLE
RD-15224: Implement a closable iterator for handling row streams.

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -840,7 +840,15 @@ class GrpcStreamIterator:
                 f"Cancelling gRPC stream for table {self._table_id}",
                 WARNING
             )
-            self._stream.cancel()
+            try:
+                self._stream.cancel()
+            except Exception as e:
+                # Log and continue. Typically we don't want a cancel() error
+                # to overshadow the original cause of a shutdown or error.
+                log_to_postgres(
+                    f"Error canceling gRPC stream for table {self._table_id}: {e}",
+                    WARNING
+                )
 
 
 def build_row(items):


### PR DESCRIPTION
If the results iterator is closed prematurely, it should also close the gRPC stream to prevent the other end from continuing to produce results unnecessarily.

It was tested by running a long query (JIRA) and hit ^C. Also tried to run a query till the end of the stream.