### PR TITLE
Fixed RD-15363: DAS FDW isn't forwarding LIKE and ILIKE

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -646,13 +646,13 @@ def operator_to_grpc_operator(operator):
         return Operator.GREATER_THAN
     elif operator == '>=':
         return Operator.GREATER_THAN_OR_EQUAL
-    elif operator == 'LIKE':
+    elif operator == '~~':
         return Operator.LIKE
-    elif operator == 'NOT LIKE':
+    elif operator == '!~~':
         return Operator.NOT_LIKE
-    elif operator == 'ILIKE':
+    elif operator == '~~*':
         return Operator.ILIKE
-    elif operator == 'NOT ILIKE':
+    elif operator == '!~~*':
         return Operator.NOT_ILIKE
     elif operator == '+':
         return Operator.PLUS


### PR DESCRIPTION
Without the patch, none of these operations is pushed down as a DAS predicate.

With the patch:
```sql
SELECT * FROM chinook.track WHERE name LIKE '%rock%' LIMIT 3;
[info]   quals {
[info]     name: "name"
[info]     simple_qual {
[info]       operator: LIKE
[info]       value {
[info]         string {
[info]           v: "%rock%"
[info]         }
[info]       }
[info]     }
```
```sql
SELECT * FROM chinook.track WHERE name NOT LIKE '%rock%' LIMIT 3;
[info]   quals {
[info]     name: "name"
[info]     simple_qual {
[info]       operator: NOT_LIKE
[info]       value {
[info]         string {
[info]           v: "%rock%"
[info]         }
[info]       }
[info]     }
```
```sql
SELECT * FROM chinook.track WHERE name ILIKE '%rock%' LIMIT 3;
[info]   quals {
[info]     name: "name"
[info]     simple_qual {
[info]       operator: ILIKE
[info]       value {
[info]         string {
[info]           v: "%rock%"
[info]         }
[info]       }
[info]     }
```
```sql
SELECT * FROM chinook.track WHERE name NOT ILIKE '%rock%' LIMIT 3;
[info]   quals {
[info]     name: "name"
[info]     simple_qual {
[info]       operator: NOT_ILIKE
[info]       value {
[info]         string {
[info]           v: "%rock%"
[info]         }
[info]       }
[info]     }
```