### PR TITLE
Fixed RD-15367: Wrong attribute read in Python

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -173,7 +173,7 @@ class DASFdw(ForeignDataWrapper):
 
         out = []
         for sk in response.sort_keys:
-            out.append(SortKey(attname=sk.name, attnum=sk.pos, is_reversed=sk.isReversed, nulls_first=sk.nullsFirst, collate=sk.collate))
+            out.append(SortKey(attname=sk.name, attnum=sk.pos, is_reversed=sk.is_reversed, nulls_first=sk.nulls_first, collate=sk.collate))
         return out
 
 


### PR DESCRIPTION
It is an error in picking fields from a data structure.
```sql
SELECT * from chinook.genre ORDER BY name;
ERROR:  Error in python: AttributeError
DETAIL:  isReversed
```
Now:
```sql
SELECT * from chinook.genre ORDER BY name;
 genre_id |        name        
----------+--------------------
       23 | Alternative
        4 | Alternative & Punk
        6 | Blues
       11 | Bossa Nova
       24 | Classical
       22 | Comedy
       21 | Drama
       12 | Easy Listening
       15 | Electronica/Dance
       13 | Heavy Metal
       17 | Hip Hop/Rap
        2 | Jazz
        7 | Latin
        3 | Metal
       25 | Opera
        9 | Pop
       14 | R&B/Soul
        8 | Reggae
        1 | Rock
        5 | Rock And Roll
       20 | Sci Fi & Fantasy
       18 | Science Fiction
       10 | Soundtrack
       19 | TV Shows
       16 | World
(25 rows)
```
Also the RD-15367 ran successfully.