### PR TITLE
Error handling: Isolate error messages from their originating exception

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -94,22 +94,22 @@ class DASFdw(ForeignDataWrapper):
         raise MulticornException("Server unavailable", detail=json.dumps(error_struct))
 
     @staticmethod
-    def _raise_unauthenticated(das_name, das_type, das_url, table_name, cause=None):
-        error_struct = {'code': 'UNAUTHENTICATED', 'das_name': das_name, 'das_type': das_type, 'das_url': das_url, 'table_name': table_name}
+    def _raise_unauthenticated(message, das_name, das_type, das_url, table_name, cause=None):
+        error_struct = {'code': 'UNAUTHENTICATED', 'message': message, 'das_name': das_name, 'das_type': das_type, 'das_url': das_url, 'table_name': table_name}
         if cause:
             error_struct['cause'] = str(cause)
         raise MulticornException("Unauthenticated", detail=json.dumps(error_struct))
 
     @staticmethod
-    def _raise_permission_denied(das_name, das_type, das_url, table_name, cause=None):
-        error_struct = {'code': 'PERMISSION_DENIED', 'das_name': das_name, 'das_type': das_type, 'das_url': das_url, 'table_name': table_name}
+    def _raise_permission_denied(message, das_name, das_type, das_url, table_name, cause=None):
+        error_struct = {'code': 'PERMISSION_DENIED', 'message': message, 'das_name': das_name, 'das_type': das_type, 'das_url': das_url, 'table_name': table_name}
         if cause:
             error_struct['cause'] = str(cause)
         raise MulticornException("Permission denied", detail=json.dumps(error_struct))
 
     @staticmethod
-    def _raise_invalid_argument(das_name, das_type, das_url, table_name, cause=None):
-        error_struct = {'code': 'INVALID_ARGUMENT', 'das_name': das_name, 'das_type': das_type, 'das_url': das_url, 'table_name': table_name}
+    def _raise_invalid_argument(message, das_name, das_type, das_url, table_name, cause=None):
+        error_struct = {'code': 'INVALID_ARGUMENT', 'message': message, 'das_name': das_name, 'das_type': das_type, 'das_url': das_url, 'table_name': table_name}
         if cause:
             error_struct['cause'] = str(cause)
         raise MulticornException("Invalid argument", detail=json.dumps(error_struct))
@@ -220,13 +220,13 @@ class DASFdw(ForeignDataWrapper):
                         )
 
                 if code == grpc.StatusCode.UNAUTHENTICATED:
-                    DASFdw._raise_unauthenticated(das_name, das_type, das_url, table_name, cause=e)
+                    DASFdw._raise_unauthenticated(e.details(), das_name, das_type, das_url, table_name, cause=e)
 
                 if code == grpc.StatusCode.PERMISSION_DENIED:
-                    DASFdw._raise_permission_denied(das_name, das_type, das_url, table_name, cause=e)
+                    DASFdw._raise_permission_denied(e.details(), das_name, das_type, das_url, table_name, cause=e)
 
                 if code == grpc.StatusCode.INVALID_ARGUMENT:
-                    DASFdw._raise_invalid_argument(das_name, das_type, das_url, table_name, cause=e)
+                    DASFdw._raise_invalid_argument(e.details(), das_name, das_type, das_url, table_name, cause=e)
 
                 # Anything else => generic error
                 DASFdw._raise_internal_error("gRPC error calling remote DAS server", cause=e)
@@ -1076,11 +1076,11 @@ class GrpcStreamIterator:
             if code == grpc.StatusCode.UNAVAILABLE:
                 DASFdw._raise_unavailable(self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
             elif code == grpc.StatusCode.UNAUTHENTICATED:
-                DASFdw._raise_unauthenticated(self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
+                DASFdw._raise_unauthenticated(e.details(), self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
             elif code == grpc.StatusCode.PERMISSION_DENIED:
-                DASFdw._raise_permission_denied(self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
+                DASFdw._raise_permission_denied(e.details(), self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
             elif code == grpc.StatusCode.INVALID_ARGUMENT:
-                DASFdw._raise_invalid_argument(self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
+                DASFdw._raise_invalid_argument(e.details(), self._das_name, self._das_type, self._das_url, self._table_name, cause=e)
             else:
                 # Notably, we do not handle NOT_FOUND here, as that should not happen in a stream.
                 # Instead, we expect it to be handled in a previous call to get_rel_size.


### PR DESCRIPTION
If getting an `INVALID_ARGUMENT` error, the `DETAIL` includes a field called `message` that contains the `details()` string of the gRPC error, which is what the DASSdk exception message is: e.g.
```scala
if (v.getYear <= 2000) {
   throw new IllegalArgumentException(s"Invalid date: $v (only > 2000 supported)")
}
```
leads to this in the dictionary:
```
`"message": "Invalid date: year: 1999\nmonth: 1\nday: 1\n (only > 2000 supported)"`
```
The `cause` field is the full string representation of the originating exception:
```
ERROR:  Invalid argument
DETAIL:  {"code": "INVALID_ARGUMENT", "message": "Invalid date:
year: 1999\nmonth: 1\nday: 1\n (only > 2000 supported)", "das_name":
"localhost:50051", "das_type": "mock", "das_url": "localhost:50051",
"table_name": "events", "cause": "<_InactiveRpcError of RPC that
terminated with:\n\tstatus = StatusCode.INVALID_ARGUMENT\n\tdetails
= \"Invalid date: year: 1999\nmonth: 1\nday: 1\n (only > 2000
supported)\"\n\tdebug_error_string = \"UNKNOWN:Error received from
peer  {created_time:\"2025-02-26T15:06:31.645698+01:00\", grpc_status:3,
grpc_message:\"Invalid date: year: 1999\\nmonth: 1\\nday: 1\\n (only
> 2000 supported)\"}\"\n>"}
```
Same with `PERMISSION_DENIED`, `UNAUTHENTICATED` and `UNIMPLEMENTED`:
```
ERROR:  Permission denied
DETAIL:  {"code": "UNSUPPORTED_OPERATION", "message": "unsupported
operation", "das_name": "localhost:50051", "das_type": "mock",
"das_url": "localhost:50051", "table_name": "small", "cause":
"<_InactiveRpcError of RPC that terminated with:\n\tstatus =
StatusCode.UNIMPLEMENTED\n\tdetails = \"unsupported
operation\"\n\tdebug_error_string = \"UNKNOWN:Error received from
peer  {created_time:\"2025-02-26T15:37:37.095474+01:00\", grpc_status:12,
grpc_message:\"unsupported operation\"}\"\n>"}
```
```
ERROR:  Unauthenticated
DETAIL:  {"code": "UNAUTHENTICATED", "message": "Wrong password",                                                                                                                                   
"das_name": "localhost:50051", "das_type": "mock", "das_url":
"localhost:50051", "table_name": "events", "cause": "<_InactiveRpcError
of RPC that terminated with:\n\tstatus =
StatusCode.UNAUTHENTICATED\n\tdetails = \"Wrong
password\"\n\tdebug_error_string = \"UNKNOWN:Error received from
peer  {created_time:\"2025-02-26T15:16:37.598023+01:00\", grpc_status:16,
grpc_message:\"Wrong password\"}\"\n>"}
```
```
ERROR:  Unsupported operation
DETAIL:  {"code": "UNSUPPORTED_OPERATION", "message": "unsupported
operation", "das_name": "localhost:50051", "das_type": "mock",
"das_url": "localhost:50051", "table_name": "small", "cause":
"<_InactiveRpcError of RPC that terminated with:\n\tstatus =
StatusCode.UNIMPLEMENTED\n\tdetails = \"unsupported
operation\"\n\tdebug_error_string = \"UNKNOWN:Error received from
peer  {created_time:\"2025-02-26T15:37:37.095474+01:00\", grpc_status:12,
grpc_message:\"unsupported operation\"}\"\n>"}
```