### PR TITLE
Fix retry loop that keeps the old stub

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -193,17 +193,7 @@ class DASFdw(ForeignDataWrapper):
                 if code == grpc.StatusCode.NOT_FOUND:
                     if allow_reregister and reregister_callback is not None:
                         log_to_postgres('gRPC attempting registration and retry...', WARNING)
-                        try:
-                            reregister_callback()
-                        except Exception as rr_ex:
-                            DASFdw._raise_registration_failed(
-                                "registration failed after unavailability",
-                                das_name=das_name,
-                                das_type=das_type,
-                                das_url=das_url,
-                                table_name=table_name,
-                                cause=rr_ex
-                            )
+                        reregister_callback()
                         allow_reregister = False
                         # Try the call again after re-registration
                         continue


### PR DESCRIPTION
Two patches here:

* Fixed by ensuring the stub_caller systematically resolves the current stub by calling a function. Another implementation would have been to store the three stubs in a `dict`: `{'registration': registration_stub, 'table': table_stub, etc.}` and pass the key string to the logic. I found it more confusing.
* Don't catch exceptions out of `reregister_callback` because it's implemented using `safe_call`, which propagates a multicorn exception. That permits to report an "authentication error" to the top instead of wrapping it into a generic "registration error".