### PR TITLE
Match protobuf (runtime) version with grpcio-tools (codegen)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "requests", "grpcio-tools"]
+requires = ["setuptools", "wheel", "requests", "grpcio-tools==1.71.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup(
         '': ['licenses/*', 'downloaded/*'],  # Exclude any files in these folders
     },
     install_requires=[
-        'protobuf',
+        'protobuf==5.29.4', # protobuf runtime that matches the grpcio-tools dependency
         'googleapis-common-protos',
         'grpcio'
     ],


### PR DESCRIPTION
When we load our Python code, a warning shows the Python classes were generated with a tool using a version 1-major away from what is used at runtime.
```
.../site-packages/google/protobuf/runtime_version.py:98: UserWarning: Protobuf 
gencode version 5.29.0 is exactly one major version older than the runtime
version 6.30.2 at com/rawlabs/protocol/das/v1/common/das.proto. Please update
the gencode to avoid compatibility violations in the next runtime release.
```

My investigation: I believe that's because `grpcio-tools` (a dependency of the build system) latest version, depends on `protobuf 5.x`, while we install latest `protobuf` (which is 6.x) in `setup.py`.
```
curl -s https://pypi.org/pypi/grpcio-tools/1.71.0/json
```
(stripped output) See it depends on `5.x`
```json
{
  "info": {
    "requires_dist": [
      "protobuf<6.0dev,>=5.26.1",
      "grpcio>=1.71.0",
      "setuptools"
    ],
    "version": "1.71.0",
  }
}
```
If forcing latest `protobuf 5.x` the warning disappears.

I also force a version for `grpcio-tools` to stabilize it too.