### PR TITLE
Fixed RD-15552: DAS functions broken after passing HTTP headers and scopes

### DIFF
--- a/multicorn_das/__init__.py
+++ b/multicorn_das/__init__.py
@@ -809,7 +809,7 @@ class DASFunction(DASBase, ForeignFunction):
         send it via gRPC, and convert the result to a Python object.
         """
         log_to_postgres(
-            f"Executing function {self.function_name} with args={named_args}, env={env}",
+            f"Executing function {self.function_name} with args={named_args}",
             DEBUG
         )
 
@@ -835,9 +835,6 @@ class DASFunction(DASBase, ForeignFunction):
             args=final_args,
             env=env
         )
-        if env is not None:
-            request.env.CopyFrom(Environment(env=env))
-
         log_to_postgres(f"ExecuteFunctionRequest: {request}", DEBUG)
 
         # 4. Call the remote function via a gRPC unary RPC


### PR DESCRIPTION
Half the code had been fixed and this wasn't tested.

Just running a DAS function is enough to spot the problem. With that patch, one can execute functions.